### PR TITLE
failOnMissingWebXml added for maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.1.1</version>
+				<configuration>
+					<failOnMissingWebXml>false</failOnMissingWebXml>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
This option will be used to stop error while running maven package